### PR TITLE
Update dependency regex pattern

### DIFF
--- a/gemfileparser/__init__.py
+++ b/gemfileparser/__init__.py
@@ -62,7 +62,7 @@ class GemfileParser(object):
 
     gemspec_add_dvtdep_regex = re.compile(r".*add_development_dependency(?P<line>.*)")
     gemspec_add_rundep_regex = re.compile(r".*add_runtime_dependency(?P<line>.*)")
-    gemspec_add_dep_regex = re.compile(r".*dependency(?P<line>.*)")
+    gemspec_add_dep_regex = re.compile(r".*add_dependency(?P<line>.*)")
 
     def __init__(self, filepath, appname=''):
         self.filepath = filepath

--- a/tests/logstash-mixin-ecs_compatibility_support.gemspec
+++ b/tests/logstash-mixin-ecs_compatibility_support.gemspec
@@ -1,0 +1,24 @@
+Gem::Specification.new do |s|
+  s.name          = 'logstash-mixin-ecs_compatibility_support'
+  s.version       = '1.3.0'
+  s.licenses      = %w(Apache-2.0)
+  s.summary       = "Support for the ECS-Compatibility mode introduced in Logstash 7.x, for plugins wishing to use this API on older Logstashes"
+  s.description   = "This gem is meant to be a dependency of any Logstash plugin that wishes to use the ECS-Compatibility mode introduced in Logstash 7.x while maintaining backward-compatibility with earlier Logstash releases. When, used on older Logstash versions this adapter provides an implementation of ECS-Compatibility mode that can be controlled at the plugin instance level."
+  s.authors       = %w(Elastic)
+  s.email         = 'info@elastic.co'
+  s.homepage      = 'https://github.com/logstash-plugins/logstash-mixin-ecs_compatibility_support'
+  s.require_paths = %w(lib)
+
+  s.files = %w(lib spec vendor).flat_map{|dir| Dir.glob("#{dir}/**/*")}+Dir.glob(["*.md","LICENSE"])
+
+  s.test_files = s.files.grep(%r{^(test|spec|features)/})
+
+  s.platform = RUBY_PLATFORM
+
+  s.add_runtime_dependency 'logstash-core', '>= 6.0.0'
+
+  s.add_development_dependency 'logstash-devutils'
+  s.add_development_dependency 'rspec', '~> 3.9'
+  s.add_development_dependency 'rspec-its', '~>1.3'
+  s.add_development_dependency 'logstash-codec-plain'
+end

--- a/tests/logstash-mixin-ecs_compatibility_support.gemspec-expected.json
+++ b/tests/logstash-mixin-ecs_compatibility_support.gemspec-expected.json
@@ -1,0 +1,66 @@
+{
+  "development": [
+    {
+      "name": "logstash-devutils",
+      "requirement": [],
+      "autorequire": "",
+      "source": "",
+      "parent": [
+        ""
+      ],
+      "group": "development"
+    },
+    {
+      "name": "rspec",
+      "requirement": [
+        "~> 3.9"
+      ],
+      "autorequire": "",
+      "source": "",
+      "parent": [
+        ""
+      ],
+      "group": "development"
+    },
+    {
+      "name": "rspec-its",
+      "requirement": [
+        "~>1.3"
+      ],
+      "autorequire": "",
+      "source": "",
+      "parent": [
+        ""
+      ],
+      "group": "development"
+    },
+    {
+      "name": "logstash-codec-plain",
+      "requirement": [],
+      "autorequire": "",
+      "source": "",
+      "parent": [
+        ""
+      ],
+      "group": "development"
+    }
+  ],
+  "runtime": [
+    {
+      "name": "logstash-core",
+      "requirement": [
+        ">= 6.0.0"
+      ],
+      "autorequire": "",
+      "source": "",
+      "parent": [
+        ""
+      ],
+      "group": "runtime"
+    }
+  ],
+  "dependency": [],
+  "test": [],
+  "production": [],
+  "metrics": []
+}

--- a/tests/test_gemfileparser.py
+++ b/tests/test_gemfileparser.py
@@ -65,3 +65,6 @@ def test_gemspec_2():
 
 def test_gemspec_3():
     check_gemparser_results('tests/arel.gemspec')
+
+def test_gemspec_4():
+    check_gemparser_results('tests/logstash-mixin-ecs_compatibility_support.gemspec')


### PR DESCRIPTION
- Update dependency regex pattern to match for "add_dependency" rather than just "dependency"
- This fixes an issue where the word "dependency" in the description field would cause the GemfileParser to use the description as a dependency name
- Add new test

Signed-off-by: Jono Yang <jyang@nexb.com>